### PR TITLE
solve issue running redis_setup.sh

### DIFF
--- a/redis_setup.sh
+++ b/redis_setup.sh
@@ -1,7 +1,7 @@
 
 #It will check, if docker is not installed then install it.
 docker -v
-if [ echo "$?" = "127" ]
+if [ "$?" = "127" ]
 then
 sudo apt-get update
 sudo apt-get install docker


### PR DESCRIPTION
fixes #80 

**Checklist**

- my branch is upto date with upstream/develop branch
- Everything works and tested for Python 3.5.2 and above

**Description**

 While running the shell file redis_setup.sh to download docker and other requirements. It gave an error and do not download the docker even when if docker was not installed. It was due to an error in argument of if-else statement . So if statement is never executed and always else is executed.

**Change logs**

fix error in if-else statement in redis_setup.sh

