### PR TITLE
Use 'hydra_python_core' module in place of 'hydrus.hydraspec'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+Pipfile
+Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pipenv generated filespip 
 Pipfile
 Pipfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.6-dev"  # 3.6 development branch
   - "3.7-dev"
 install:
-  - pip install -e git+https://github.com/HTTP-APIs/hydrus#egg=hydrus
+  - pip install -e git+https://github.com/HTTP-APIs/hydra-python-core#egg=hydra_python_core
   - pip install -e .
   
 script: python -m unittest discover

--- a/hydra_agent/hydra_graph.py
+++ b/hydra_agent/hydra_graph.py
@@ -2,7 +2,7 @@ import redis
 from redisgraph import Graph, Node
 import urllib.request
 import json
-from hydra_python_core import doc_maker 
+from hydra_python_core import doc_maker, doc_writer
 from graphviz import Digraph
 from hydra_agent.classes_objects import ClassEndpoints,RequestError
 from hydra_agent.collections_endpoint import CollectionEndpoints

--- a/hydra_agent/hydra_graph.py
+++ b/hydra_agent/hydra_graph.py
@@ -2,8 +2,7 @@ import redis
 from redisgraph import Graph, Node
 import urllib.request
 import json
-from hydrus.hydraspec import doc_maker
-import hydrus
+from hydra_python_core import doc_maker 
 from graphviz import Digraph
 from hydra_agent.classes_objects import ClassEndpoints,RequestError
 from hydra_agent.collections_endpoint import CollectionEndpoints
@@ -21,12 +20,12 @@ class InitialGraph:
         for support_property in api_doc.entrypoint.entrypoint.supportedProperty:
             if isinstance(
                     support_property,
-                    hydrus.hydraspec.doc_writer.EntryPointClass):
+                    doc_writer.EntryPointClass):
                 self.class_endpoints[support_property.name] = support_property.id_
 
             if isinstance(
                     support_property,
-                    hydrus.hydraspec.doc_writer.EntryPointCollection):
+                    doc_writer.EntryPointCollection):
                 self.collection_endpoints[support_property.name] = support_property.id_
 
         if len(self.class_endpoints.keys())>0:

--- a/hydra_agent/querying_mechanism.py
+++ b/hydra_agent/querying_mechanism.py
@@ -4,7 +4,7 @@ import logging
 from hydra_agent.hydra_graph import InitialGraph
 import urllib.request
 import json
-from hydrus.hydraspec import doc_maker
+from hydra_python_core import doc_maker
 from urllib.error import URLError, HTTPError
 from hydra_agent.collections_endpoint import CollectionEndpoints
 from hydra_agent.classes_objects import ClassEndpoints,RequestError

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ httplib2
 redis
 redisgraph
 graphviz
--e git+https://github.com/HTTP-APIs/hydrus.git#egg=hydrus
+-e git+https://github.com/HTTP-APIs/hydra-python-core.git#egg=hydra_python_core


### PR DESCRIPTION
**Solves** #86 

As has been done with moving out the hydra_python_core module that used to be hydraspec, the python hydra-agent needs to be updated similarly.

## Changes
- Reflected moving out of 'hydraspec' as hydra_python_core module, updated  all use of same within the repo.