### PR TITLE
Fixing Redis breaking change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pipenv generated filespip 
+Pipfile
+Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,13 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+share
+include
+bin
+
+# pipenv generated filespip 
+Pipfile
+Pipfile.lock
 
 # Spyder project settings
 .spyderproject
@@ -100,6 +107,5 @@ ENV/
 # mypy
 .mypy_cache/
 
-# pipenv generated filespip 
-Pipfile
-Pipfile.lock
+#build packages
+src 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.6-dev"  # 3.6 development branch
   - "3.7-dev"
 install:
-  - pip install -e git+https://github.com/HTTP-APIs/hydrus#egg=hydrus
+  - pip install -e git+https://github.com/HTTP-APIs/hydra-python-core#egg=hydra_python_core
   - pip install -e .
   
 script: python -m unittest discover

--- a/hydra_agent/hydra_graph.py
+++ b/hydra_agent/hydra_graph.py
@@ -2,8 +2,7 @@ import redis
 from redisgraph import Graph, Node
 import urllib.request
 import json
-from hydrus.hydraspec import doc_maker
-import hydrus
+from hydra_python_core import doc_maker, doc_writer
 from graphviz import Digraph
 from hydra_agent.classes_objects import ClassEndpoints,RequestError
 from hydra_agent.collections_endpoint import CollectionEndpoints
@@ -21,12 +20,12 @@ class InitialGraph:
         for support_property in api_doc.entrypoint.entrypoint.supportedProperty:
             if isinstance(
                     support_property,
-                    hydrus.hydraspec.doc_writer.EntryPointClass):
+                    doc_writer.EntryPointClass):
                 self.class_endpoints[support_property.name] = support_property.id_
 
             if isinstance(
                     support_property,
-                    hydrus.hydraspec.doc_writer.EntryPointCollection):
+                    doc_writer.EntryPointCollection):
                 self.collection_endpoints[support_property.name] = support_property.id_
 
         if len(self.class_endpoints.keys())>0:

--- a/hydra_agent/querying_mechanism.py
+++ b/hydra_agent/querying_mechanism.py
@@ -4,7 +4,7 @@ import logging
 from hydra_agent.hydra_graph import InitialGraph
 import urllib.request
 import json
-from hydrus.hydraspec import doc_maker
+from hydra_python_core import doc_maker
 from urllib.error import URLError, HTTPError
 from hydra_agent.collections_endpoint import CollectionEndpoints
 from hydra_agent.classes_objects import ClassEndpoints,RequestError

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ rdflib
 rdflib-jsonld
 uritemplate
 httplib2
-redis
+redis==2.10.6
 redisgraph
 graphviz
 -e git+https://github.com/HTTP-APIs/hydra-python-core.git#egg=hydra_python_core

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ httplib2
 redis
 redisgraph
 graphviz
--e git+https://github.com/HTTP-APIs/hydrus.git#egg=hydrus
+-e git+https://github.com/HTTP-APIs/hydra-python-core.git#egg=hydra_python_core


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes # [86](https://github.com/HTTP-APIs/python-hydra-agent/issues/86)

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
Setting Redis version as 2 because of breaking change in Redis 3
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


#### Fixed
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->
redis.exceptions.DataError: Invalid input of type: 'dict'. Convert to a byte, string or number first.
(redis_connection.set("EntryPoint", entrypoint_properties)...)

Set Redis version because of backwards incompatibility from Redis 2 to Redis 3, which now only accepts values as bytes, strings or numbers.

<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->