### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ redis
 graphviz
 requests
 python-socketio
--e git+https://github.com/RedisGraph/redisgraph-py#egg=redisgraph
--e git+https://github.com/http-apis/hydra-python-core@master#egg=hydra_python_core
+redisgraph
+hydra_python_core


### PR DESCRIPTION
redisgraph and hydra_python_core are now on PyPi

It seems the version provided in PyPi is not the same provided from Github.