### PR TITLE
Fix PUT and GET on a resource

### DIFF
--- a/hydra_agent/redis_core/graphutils_operations.py
+++ b/hydra_agent/redis_core/graphutils_operations.py
@@ -113,7 +113,7 @@ class GraphOperations():
                     embedded_url = eval(resource[supported_prop.title])['@id']
                     embedded_type = eval(resource[supported_prop.title])['@type']
                     new_resource = {'parent_id': resource['@id'], 'parent_type': resource['@type'],
-                                    'embedded_url': "{}{}".format(self.entrypoint, embedded_url),
+                                    'embedded_url': "{}".format(embedded_url),
                                     'embedded_type': embedded_type}
                     embedded_resources.append(new_resource)
             return embedded_resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
-rdflib
-rdflib-jsonld
-uritemplate
-httplib2
-redis
-graphviz
-requests
-python-socketio
-hydra_python_core
+graphviz==0.19.1
+httplib2==0.20.2
+hydra-python-core==0.3.1
+PyLD==2.0.3
+python-engineio==3.11.2
+python-socketio==4.4.0
+rdflib==6.1.1
+rdflib-jsonld==0.6.2
+redis==4.1.0
 -e git+https://github.com/RedisGraph/redisgraph-py@d790e35b7017510c4baad85e3c572249a9ed7279#egg=redisgraph
+requests==2.26.0
+uritemplate==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@ graphviz==0.19.1
 httplib2==0.20.2
 hydra-python-core==0.3.1
 PyLD==2.0.3
-python-engineio==3.11.2
 python-socketio==4.4.0
-rdflib==6.1.1
+rdflib==5.0.0
 rdflib-jsonld==0.6.2
 redis==4.1.0
 -e git+https://github.com/RedisGraph/redisgraph-py@d790e35b7017510c4baad85e3c572249a9ed7279#egg=redisgraph


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #170 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
Earilier `GET` request on path `/<resource>/<id>`, and `PUT` request on `/<resource>` results in `requests.exceptions.InvalidURL`. Now `GET` and `PUT` works on an single resource.

On `PUT` request of the following resource: 
```new_resource = {
    "@type": "Drone",
    "DroneState": {
        "@type": "State",
        "Battery": "50%",
        "Direction": "N",
        "Position": "50.34",
        "SensorStatus": "Active",
        "Speed": "100"
    },
    "MaxSpeed": "500",
    "Sensor": "Active",
    "model": "Drone_1",
    "name": "Drone1"
}
agent.put("http://localhost:8080/serverapi/Drone/", new_resource)
```
 This is the corresponding created resource:
![Screenshot from 2021-12-29 19-02-44](https://user-images.githubusercontent.com/90337323/147669047-f419ba71-8390-4407-9240-b063dcdce40b.png)

### Change logs
Changed duplicate `entrypoint` url.
