### PR TITLE
Migrate test suite from unittest to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_script:
 python:
   - "3.6"
   - "3.6-dev" # 3.6 development branch
-  - "3.7"
-  - "3.7-dev" # 3.7 development branch
+  - "3.8"
+  - "3.8-dev" # 3.8 development branch
 install:
   - pip install -r requirements.txt --no-cache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 services:
   - docker
-  
+
 before_script:
   - docker run -d -p 6379:6379 -it --rm --name redisgraph redislabs/redisgraph:2.0-edge
 
 python:
   - "3.6"
-  - "3.6-dev"  # 3.6 development branch
+  - "3.6-dev" # 3.6 development branch
   - "3.7"
   - "3.7-dev" # 3.7 development branch
 install:
   - pip install -r requirements.txt --no-cache
-  
-script: python -m unittest discover
+
+script: pytest

--- a/hydra_agent/agent.py
+++ b/hydra_agent/agent.py
@@ -123,20 +123,20 @@ class Agent(Session, socketio.ClientNamespace, socketio.Client):
                 except KeyError:
                     response = response_body
 
-        if response.status_code == 200:
-            # Graph_operations returns the embedded resources if finding any
-            embedded_resources = \
-                self.graph_operations.get_processing(url, response.json())
-            self.process_embedded(embedded_resources)
-            if response.json()['@type'] in self.api_doc.parsed_classes:
-                return response.json()
-            else:
-                if follow_partial_links:
-                    return Paginator(response=response.json())
-                else:
+            if response.status_code == 200:
+                # Graph_operations returns the embedded resources if finding any
+                embedded_resources = \
+                    self.graph_operations.get_processing(url, response.json())
+                self.process_embedded(embedded_resources)
+                if response.json()['@type'] in self.api_doc.parsed_classes:
                     return response.json()
-        else:
-            return response.text
+                else:
+                    if follow_partial_links:
+                        return Paginator(response=response.json())
+                    else:
+                        return response.json()
+            else:
+                return response.text
 
     def put(self, url: str, new_object: dict) -> Tuple[dict, str]:
         """CREATE resource in the Server/cache it on Redis

--- a/hydra_agent/tests/conftest.py
+++ b/hydra_agent/tests/conftest.py
@@ -156,6 +156,7 @@ def redis_db_execute_command_query(redis_reply, mocker):
 
 @pytest.fixture(scope="module")
 def constants():
+    """Constants for tests"""
     return {
         "host": "localhost",
         "test_url": "TestURL",
@@ -184,26 +185,31 @@ def setup_agent_for_tests(class_mocker, request, constants):
 
 @pytest.fixture
 def get_session_mock(mocker):
+    """Mock for patching GET request"""
     return mocker.patch("hydra_agent.agent.Session.get")
 
 
 @pytest.fixture
 def put_session_mock(mocker):
+    """Mock for patching PUT request"""
     return mocker.patch("hydra_agent.agent.Session.put")
 
 
 @pytest.fixture
 def post_session_mock(mocker):
+    """Mock for patching POST request"""
     return mocker.patch("hydra_agent.agent.Session.post")
 
 
 @pytest.fixture
 def delete_session_mock(mocker):
+    """Mock for patching DELETE request"""
     return mocker.patch("hydra_agent.agent.Session.delete")
 
 
 @pytest.fixture
 def state_object(constants):
+    """Dummy drone state object for tests"""
     state_object = {
         "@context": "/api/contexts/State.jsonld",
         "@id": "/api/State/1",
@@ -220,6 +226,7 @@ def state_object(constants):
 
 @pytest.fixture
 def simplified_collection(constants):
+    """Dummy collection for tests"""
     return {
         "@context": f"/{constants['api_name']}/contexts/DroneCollection.jsonld",
         "@id": f"/{constants['api_name']}/DroneCollection/1",
@@ -251,6 +258,7 @@ def simplified_collection(constants):
 
 @pytest.fixture
 def new_object():
+    """Dummy drone object for tests"""
     new_object = {
         "@type": "Drone",
         "DroneState": {
@@ -272,6 +280,7 @@ def new_object():
 
 @pytest.fixture
 def drone_res(constants):
+    """Dummy drone response for tests"""
     drone_res = {
         "@context": "/api/contexts/Drone.jsonld",
         "@id": "/api/Drone/1",

--- a/hydra_agent/tests/conftest.py
+++ b/hydra_agent/tests/conftest.py
@@ -161,7 +161,7 @@ def constants():
         "host": "localhost",
         "test_url": "TestURL",
         "redis_port": 6379,
-        "entrypoint_url": "http://localhost:8080/serverapi/",
+        "entrypoint_url": "http://localhost:8080/serverapi",
         "api_name": "serverapi",
         "graph_name": "apigraph",
     }
@@ -211,8 +211,8 @@ def delete_session_mock(mocker):
 def state_object(constants):
     """Dummy drone state object for tests"""
     state_object = {
-        "@context": "/api/contexts/State.jsonld",
-        "@id": "/api/State/1",
+        "@context": f"/{constants['api_name']}/contexts/State.jsonld",
+        "@id": f"/{constants['api_name']}/State/1",
         "@type": "State",
         "Battery": "sensor Ex",
         "Direction": "North",
@@ -242,16 +242,16 @@ def simplified_collection(constants):
                     "hydra:variable": "DroneState[Speed]",
                 }
             ],
-            "hydra:template": "/serverapi/Drone(DroneState[Speed])",
+            "hydra:template": f"/{constants['api_name']}/Drone(DroneState[Speed])",
             "hydra:variableRepresentation": "hydra:BasicRepresentation",
         },
         "totalItems": 1,
         "view": {
-            "@id": "/serverapi/DroneCollection?page=1",
+            "@id": f"/{constants['api_name']}/DroneCollection?page=1",
             "@type": "PartialCollectionView",
-            "first": "/serverapi/DroneCollection?page=1",
-            "last": "/serverapi/DroneCollection?page=1",
-            "next": "/serverapi/DroneCollection?page=1",
+            "first": f"/{constants['api_name']}/DroneCollection?page=1",
+            "last": f"/{constants['api_name']}/DroneCollection?page=1",
+            "next": f"/{constants['api_name']}/DroneCollection?page=1",
         },
     }
 
@@ -282,11 +282,11 @@ def new_object():
 def drone_res(constants):
     """Dummy drone response for tests"""
     drone_res = {
-        "@context": "/api/contexts/Drone.jsonld",
-        "@id": "/api/Drone/1",
+        "@context": f"/{constants['api_name']}/contexts/Drone.jsonld",
+        "@id": f"/{constants['api_name']}/Drone/1",
         "@type": "Drone",
         "DroneState": {
-            "@id": "/api/State/1",
+            "@id": f"/{constants['api_name']}/State/1",
             "@type": "State",
             "Battery": "C1WE92",
             "Direction": "Q9VV88",

--- a/hydra_agent/tests/conftest.py
+++ b/hydra_agent/tests/conftest.py
@@ -1,0 +1,149 @@
+import pytest
+from hydra_agent.querying_mechanism import HandleData
+from hydra_agent.querying_mechanism import (
+    EndpointQuery,
+    CollectionmembersQuery,
+    PropertiesQuery,
+    ClassPropertiesValue,
+)
+import redis
+import os
+
+
+@pytest.fixture(scope="class")
+def handle_data(request):
+    """Setting up HandleData object"""
+    request.cls.test_url = "TestURL"
+    request.cls.handle_data = HandleData()
+
+
+@pytest.fixture(scope="class")
+def endpoint_query(request, class_mocker):
+    """Setting up EndpointQuery object"""
+    class_mocker.patch("hydra_agent.querying_mechanism.RedisProxy", autospec=True)
+    request.cls.endpoint_query = EndpointQuery()
+
+
+@pytest.fixture(scope="class")
+def collection_members_query(request, class_mocker):
+    """Setting up CollectionmembersQuery object"""
+    class_mocker.patch(
+        "hydra_agent.querying_mechanism.CollectionEndpoints", autospec=True
+    )
+    class_mocker.patch("hydra_agent.querying_mechanism.RedisProxy", autospec=True)
+    api_doc, url, graph = (class_mocker.MagicMock() for i in range(3))
+    request.cls.cmq = CollectionmembersQuery(api_doc, url, graph)
+
+
+@pytest.fixture(scope="class")
+def properties_query(request, class_mocker):
+    """Setting up PropertiesQuery object"""
+    class_mocker.patch("hydra_agent.querying_mechanism.RedisProxy", autospec=True)
+    request.cls.properties_query = PropertiesQuery()
+
+
+@pytest.fixture(scope="class")
+def class_properties_value(request, class_mocker):
+    """Setting up ClassPropertiesValue object"""
+    class_mocker.patch(
+        "hydra_agent.querying_mechanism.CollectionEndpoints", autospec=True
+    )
+    class_mocker.patch("hydra_agent.querying_mechanism.RedisProxy", autospec=True)
+    api_doc, url, graph = (class_mocker.MagicMock() for i in range(3))
+    request.cls.cpv = ClassPropertiesValue(api_doc, url, graph)
+
+
+@pytest.fixture(scope="module")
+def test_database():
+    """Initialize redis database"""
+    test_db = redis.StrictRedis(host="localhost", port=6379, db=5)
+    yield test_db
+    test_db.flushdb()
+
+
+@pytest.fixture(scope="module")
+def init_db_for_redis_tests(test_database):
+    """Initialize the database by adding key, value pairs"""
+    test_database.set("foo", "bar")
+    test_database.set("hydra", "redis")
+
+
+@pytest.fixture
+def redis_reply():
+    """Returns the correct response on processing query"""
+    test_method_name = (
+        os.environ.get("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0].lower()
+    )
+    if "collection" in test_method_name:
+        return [
+            [
+                [b"p.id", b"p.operations", b"p.type"],
+                [
+                    b"vocab:EntryPoint/HttpApiLogCollection",
+                    b"['GET', 'PUT']",
+                    b"HttpApiLogCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/AnomalyCollection",
+                    b"['GET', 'PUT']",
+                    b"AnomalyCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/CommandCollection",
+                    b"['GET', 'PUT']",
+                    b"CommandCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/ControllerLogCollection",
+                    b"['GET', 'PUT']",
+                    b"ControllerLogCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/DatastreamCollection",
+                    b"['GET', 'PUT']",
+                    b"DatastreamCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/MessageCollection",
+                    b"['GET', 'PUT']",
+                    b"MessageCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/DroneLogCollection",
+                    b"['GET', 'PUT']",
+                    b"DroneLogCollection",
+                ],
+                [
+                    b"vocab:EntryPoint/DroneCollection",
+                    b"['GET', 'PUT']",
+                    b"DroneCollection",
+                ],
+            ],
+            [b"Query internal execution time: 0.089501 milliseconds"],
+        ]
+    elif "class" in test_method_name:
+        return [
+            [
+                [b"p.properties", b"p.id", b"p.operations", b"p.type"],
+                [
+                    b"['Location']",
+                    b"vocab:EntryPoint/Location",
+                    b"['POST', 'PUT', 'GET']",
+                    b"Location",
+                ],
+            ],
+            [b"Query internal execution time: 0.076224 milliseconds"],
+        ]
+    elif "entrypoint" in test_method_name:
+        return [
+            [
+                [b"p.url", b"p.id", b"p.supportedOperation"],
+                [b"http://localhost:8080/api", b"vocab:Entrypoint", b"GET"],
+            ],
+            [b"Query internal execution time: 0.071272 milliseconds"],
+        ]
+
+
+@pytest.fixture
+def redis_db_execute_command_query(redis_reply, mocker):
+    return mocker.MagicMock(return_value=redis_reply)

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -1,183 +1,97 @@
-import unittest
-from unittest.mock import patch, MagicMock, call, Mock
+import pytest
 from hydra_agent.agent import Agent
-from hydra_agent.redis_core.graphutils_operations import GraphOperations
-from hydra_agent.redis_core.redis_proxy import RedisProxy
-from redisgraph import Graph
-from hydra_agent.tests.test_examples.hydra_doc_sample import doc as drone_doc
 from hydra_agent.helpers import expand_template
 from urllib.parse import urlparse
 
-class TestAgent(unittest.TestCase):
-    """
-    TestCase for Agent Class
-    """
 
-    @patch('hydra_agent.agent.socketio.Client.connect')
-    @patch('hydra_agent.agent.Session.get')
-    def setUp(self, get_session_mock, socket_client_mock):
-        """Setting up Agent object
-        :param get_session_mock: MagicMock object for patching session.get
-                                 it's used to Mock Hydrus response to ApiDoc
-        """
-        # Mocking get for ApiDoc to Server, so hydrus doesn't need to be up
-        get_session_mock.return_value.json.return_value = drone_doc
-        socket_client_mock.return_value = None
+@pytest.mark.usefixtures("setup_agent_for_tests")
+class TestAgent:
+    """TestCase for Agent Class"""
+
+    @pytest.fixture(autouse=True)
+    def init_agent(self, constants):
+        """Setting up Agent object"""
         try:
-            self.agent = Agent("http://localhost:8080/api")
-        except SyntaxError:
-            self.setUp(self, get_session_mock, socket_client_mock)
-        except ConnectionResetError:
-            self.setUp(self, get_session_mock, socket_client_mock)
-        self.redis_proxy = RedisProxy()
-        self.redis_connection = self.redis_proxy.get_connection()
-        self.redis_graph = Graph("apigraph", self.redis_connection)
+            self.agent = Agent(constants["entrypoint_url"])
+        except (SyntaxError, ConnectionResetError):
+            self.init_agent(constants["entrypoint_url"])
 
-    @patch('hydra_agent.agent.Session.get')
-    def test_get_url(self, get_session_mock):
+    def test_get_url(self, get_session_mock, state_object):
         """Tests get method from the Agent with URL
         :param get_session_mock: MagicMock object for patching session.get
         """
-        state_object = {"@id": "/api/State/1", "@type": "State",
-                        "Battery": "sensor Ex", "Direction": "speed Ex",
-                        "DroneID": "sensor Ex", "Position": "model Ex",
-                        "SensorStatus": "sensor Ex", "Speed": "2",
-                        "@context": "/api/contexts/StateCollection.jsonld"}
-
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
-        response = self.agent.get("http://localhost:8080/api/" +
-                                  "State/1")
+        response = self.agent.get(self.entrypoint_url + "State/1")
 
-        self.assertEqual(response, state_object)
+        assert response == state_object
 
-    @patch('hydra_agent.agent.Session.get')
-    def test_get_class_properties(self, get_session_mock):
+    def test_get_class_properties(self, get_session_mock, state_object):
         """Tests get method from the Agent by class name and properties
         :param get_session_mock: MagicMock object for patching session.get
         """
-        state_object = {"@id": "/api/State/1", "@type": "State",
-                        "Battery": "sensor Ex", "Direction": "North",
-                        "DroneID": "sensor Ex", "Position": "model Ex",
-                        "SensorStatus": "sensor Ex", "Speed": "2",
-                        "@context": "/api/contexts/State.jsonld"}
 
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
-        response_url = self.agent.get("http://localhost:8080/api/" +
-                                      "State/1")
+        response_url = self.agent.get("http://localhost:8080/api/" + "State/1")
 
-        response_cached = self.agent.get(resource_type="State",
-                                         filters={"Direction": "North"},
-                                         cached_limit=1)
+        response_cached = self.agent.get(
+            resource_type="State", filters={"Direction": "North"}, cached_limit=1
+        )
 
         response_cached = response_cached[0]
-        self.assertEqual(response_url, response_cached)
+        assert response_url == response_cached
 
-        response_not_cached = self.agent.get("http://localhost:8080/api/" +
-                                             "State/1")
-        self.assertEqual(response_not_cached, response_cached)
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.put')
-    def test_get_collection(self, put_session_mock, embedded_get_mock):
+        response_not_cached = self.agent.get("http://localhost:8080/api/" + "State/1")
+        assert response_not_cached == response_cached
+
+    def test_get_collection(
+        self, get_session_mock, put_session_mock, simplified_collection
+    ):
         """Tests get method from the Agent when fetching collections
         :param put_session_mock: MagicMock object for patching session.put
-        :param embedded_get_mock: MagicMock object for patching session.get
+        :param get_session_mock: MagicMock object for patching session.get
         """
-        new_object = {"@type": "DroneCollection",
-                      "members": ["1"]}
+        new_object = {"@type": "DroneCollection", "members": ["1"]}
 
         collection_url = "http://localhost:8080/api/DroneCollection/"
         new_collection_url = collection_url + "1"
 
         put_session_mock.return_value.status_code = 201
         put_session_mock.return_value.json.return_value = new_object
-        put_session_mock.return_value.headers = {'Location': new_collection_url}
-        simplified_collection = \
-            {
-                "@context": "/api/contexts/DroneCollection.jsonld",
-                "@id": "/api/DroneCollection/1",
-                "@type": "DroneCollection",
-                "members": [
-                    {
-                        "@id": "/api/Drone/1",
-                        "@type": "Drone"
-                    }
-                ],
-                "search": {
-                    "@type": "hydra:IriTemplate",
-                    "hydra:mapping": [{
-                        "@type": "hydra:IriTemplateMapping",
-                        "hydra:property": "http://auto.schema.org/speed",
-                        "hydra:required": False,
-                        "hydra:variable": "DroneState[Speed]"}
-                    ],
-                    "hydra:template": "/serverapi/Drone(DroneState[Speed])",
-                    "hydra:variableRepresentation": "hydra:BasicRepresentation",
-                },
-                "totalItems": 1,
-                "view": {
-                    "@id": "/serverapi/DroneCollection?page=1",
-                    "@type": "PartialCollectionView",
-                    "first": "/serverapi/DroneCollection?page=1",
-                    "last": "/serverapi/DroneCollection?page=1",
-                    "next": "/serverapi/DroneCollection?page=1"
-                }
-            }
+        put_session_mock.return_value.headers = {"Location": new_collection_url}
 
-        embedded_get_mock.return_value.json.return_value = simplified_collection
-        embedded_get_mock.return_value.status_code = 200
+        get_session_mock.return_value.json.return_value = simplified_collection
+        get_session_mock.return_value.status_code = 200
         response, new_object_url = self.agent.put(collection_url, new_object)
         get_collection_url = self.agent.get(collection_url)
-        self.assertEqual(type(get_collection_url), dict)
+        assert type(get_collection_url) == dict
         # get_collection_cached = self.agent.get(resource_type="Drone",
         #                                        cached_limit=1)
         # self.assertEqual(get_collection_cached[0]["@id"],
         #                  get_collection_url['members'][0]["@id"])
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.put')
-    def test_put(self, put_session_mock, embedded_get_mock):
+    def test_put(
+        self,
+        mocker,
+        get_session_mock,
+        put_session_mock,
+        new_object,
+        state_object,
+        drone_res,
+    ):
         """Tests put method from the Agent
         :param put_session_mock: MagicMock object for patching session.put
-        :param embedded_get_mock: MagicMock object for patching session.get
+        :param get_session_mock: MagicMock object for patching session.get
         """
-        new_object = {"@type": "Drone", "DroneState": "1",
-                      "name": "Smart Drone", "model": "Hydra Drone",
-                      "MaxSpeed": "999", "Sensor": "Wind"}
-
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "1"
 
         put_session_mock.return_value.status_code = 201
         put_session_mock.return_value.json.return_value = new_object
-        put_session_mock.return_value.headers = {'Location': new_object_url}
+        put_session_mock.return_value.headers = {"Location": new_object_url}
 
-        state_object = {"@context": "/api/contexts/State.jsonld",
-                        "@id": "/api/State/1", "@type": "State",
-                        "Battery": "sensor Ex", "Direction": "speed Ex",
-                        "DroneID": "sensor Ex", "Position": "model Ex",
-                        "SensorStatus": "sensor Ex", "Speed": "2"}
-        drone_res = {
-            "@context": "/api/contexts/Drone.jsonld",
-            "@id": "/api/Drone/1",
-            "@type": "Drone",
-            "DroneState": {
-                "@id": "/api/State/1",
-                "@type": "State",
-                "Battery": "C1WE92",
-                "Direction": "Q9VV88",
-                "DroneID": "6EBGT5",
-                "Position": "A",
-                "SensorStatus": "335Y8B",
-                "Speed": "IZPSTE"
-            },
-            "MaxSpeed": "A3GZ37",
-            "Sensor": "E7JD5Q",
-            "model": "HB14CX",
-            "name": "Priaysnhu"
-        }
-        fake_responses = [Mock(), Mock(), Mock(), Mock()]
+        fake_responses = [mocker.Mock(), mocker.Mock(), mocker.Mock(), mocker.Mock()]
         fake_responses[0].json.return_value = drone_res
         fake_responses[0].status_code = 200
         fake_responses[1].json.return_value = state_object
@@ -187,78 +101,55 @@ class TestAgent(unittest.TestCase):
         fake_responses[3].json.return_value = drone_res
         fake_responses[3].status_code = 200
         # Mocking an object to be used for a property that has an embedded link
-        embedded_get_mock.return_value.status_code = 200
-        embedded_get_mock.side_effect = fake_responses
+        get_session_mock.return_value.status_code = 200
+        get_session_mock.side_effect = fake_responses
         response, new_object_url = self.agent.put(new_object_url, new_object)
 
         # Assert if object was inserted queried and inserted successfully
         get_new_object_url = self.agent.get(new_object_url)
-        self.assertEqual(get_new_object_url, drone_res)
+        assert get_new_object_url == drone_res
 
-        get_new_object_type = self.agent.get(new_object_url, filters={'name': "Smart Drone"})
-        self.assertEqual(get_new_object_url, get_new_object_type)
+        get_new_object_type = self.agent.get(
+            new_object_url, filters={"name": "Smart Drone"}
+        )
+        assert get_new_object_url == get_new_object_type
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.post')
-    @patch('hydra_agent.agent.Session.put')
-    def test_post(self, put_session_mock, post_session_mock,
-                  embedded_get_mock):
+    def test_post(
+        self,
+        put_session_mock,
+        post_session_mock,
+        get_session_mock,
+        new_object,
+        state_object,
+        drone_res,
+        mocker,
+    ):
         """Tests post method from the Agent
         :param put_session_mock: MagicMock object for patching session.put
         :param post_session_mock: MagicMock object for patching session.post
         """
-        new_object = {"@type": "Drone", "DroneState": {
-            "@type": "State", "Battery": "C1WE92", "Direction": "Q9VV88", "DroneID": "6EBGT5", "Position": "A"
-            , "SensorStatus": "335Y8B", "Speed": "IZPSTE"},
-            "MaxSpeed": "A3GZ37", "Sensor": "E7JD5Q",
-            "model": "HB14CX",
-            "name": "Priyanshu"}
-
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "2"
 
         put_session_mock.return_value.status_code = 201
         put_session_mock.return_value.json.return_value = new_object
-        put_session_mock.return_value.headers = {'Location': new_object_url}
-        state_object = {"@context": "/api/contexts/State.jsonld",
-                        "@id": "/api/State/1", "@type": "State",
-                        "Battery": "sensor Ex", "Direction": "speed Ex",
-                        "DroneID": "sensor Ex", "Position": "model Ex",
-                        "SensorStatus": "sensor Ex", "Speed": "2"}
-        drone_res = {
-            "@context": "/api/contexts/Drone.jsonld",
-            "@id": "/api/Drone/2",
-            "@type": "Drone",
-            "DroneState": {
-                "@id": "/api/State/1",
-                "@type": "State",
-                "Battery": "C1WE92",
-                "Direction": "Q9VV88",
-                "DroneID": "6EBGT5",
-                "Position": "A",
-                "SensorStatus": "335Y8B",
-                "Speed": "IZPSTE"
-            },
-            "MaxSpeed": "A3GZ37",
-            "Sensor": "E7JD5Q",
-            "model": "HB14CX",
-            "name": "Priaysnhu"
-        }
-        fake_responses = [Mock(), Mock(), Mock()]
+        put_session_mock.return_value.headers = {"Location": new_object_url}
+
+        fake_responses = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
         fake_responses[0].json.return_value = drone_res
         fake_responses[0].status_code = 200
         fake_responses[1].json.return_value = state_object
         fake_responses[1].status_code = 200
         # Mocking an object to be used for a property that has an embedded link
-        embedded_get_mock.return_value.status_code = 200
-        embedded_get_mock.side_effect = fake_responses
+        get_session_mock.return_value.status_code = 200
+        get_session_mock.side_effect = fake_responses
 
         response, new_object_url = self.agent.put(new_object_url, new_object)
 
         post_session_mock.return_value.status_code = 200
         post_session_mock.return_value.json.return_value = {"msg": "success"}
-        new_object['DroneState']['@id'] = "/api/State/1"
-        new_object['name'] = "Updated Name"
+        new_object["DroneState"]["@id"] = "/api/State/1"
+        new_object["name"] = "Updated Name"
         # Mocking an object to be used for a property that has an embedded link
         response = self.agent.post(new_object_url, new_object)
         # Assert if object was updated successfully as intended
@@ -266,53 +157,31 @@ class TestAgent(unittest.TestCase):
         fake_responses[2].status_code = 200
         get_new_object = self.agent.get(new_object_url)
 
-        self.assertEqual(get_new_object, new_object)
+        assert get_new_object == new_object
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.delete')
-    @patch('hydra_agent.agent.Session.put')
-    def test_delete(self, put_session_mock, delete_session_mock,
-                    get_session_mock):
+    def test_delete(
+        self,
+        put_session_mock,
+        delete_session_mock,
+        get_session_mock,
+        mocker,
+        new_object,
+        state_object,
+        drone_res,
+    ):
         """Tests post method from the Agent
         :param put_session_mock: MagicMock object for patching session.put
         :param delete_session_mock: MagicMock object to patch session.delete
         :param get_session_mock: MagicMock object for patching session.get
         """
-        new_object = {"@type": "Drone", "DroneState": "/api/StateCollection/1",
-                      "name": "Smart Drone", "model": "Hydra Drone",
-                      "MaxSpeed": "999", "Sensor": "Wind"}
 
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "3"
 
         put_session_mock.return_value.status_code = 201
         put_session_mock.return_value.json.return_value = new_object
-        put_session_mock.return_value.headers = {'Location': new_object_url}
-        state_object = {"@context": "/api/contexts/State.jsonld",
-                        "@id": "/api/State/1", "@type": "State",
-                        "Battery": "sensor Ex", "Direction": "speed Ex",
-                        "DroneID": "sensor Ex", "Position": "model Ex",
-                        "SensorStatus": "sensor Ex", "Speed": "2"}
-        drone_res = {
-            "@context": "/api/contexts/Drone.jsonld",
-            "@id": "/api/Drone/1",
-            "@type": "Drone",
-            "DroneState": {
-                "@id": "/api/State/1",
-                "@type": "State",
-                "Battery": "C1WE92",
-                "Direction": "Q9VV88",
-                "DroneID": "6EBGT5",
-                "Position": "A",
-                "SensorStatus": "335Y8B",
-                "Speed": "IZPSTE"
-            },
-            "MaxSpeed": "A3GZ37",
-            "Sensor": "E7JD5Q",
-            "model": "HB14CX",
-            "name": "Priaysnhu"
-        }
-        fake_responses = [Mock(), Mock(), Mock()]
+        put_session_mock.return_value.headers = {"Location": new_object_url}
+        fake_responses = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
         fake_responses[0].json.return_value = drone_res
         fake_responses[0].status_code = 200
         fake_responses[1].json.return_value = state_object
@@ -330,20 +199,16 @@ class TestAgent(unittest.TestCase):
         get_new_object = self.agent.get(new_object_url)
 
         # Assert if nothing different was returned by Redis
-        self.assertEqual(get_new_object, {"msg": "resource doesn't exist"})
+        assert get_new_object == {"msg": "resource doesn't exist"}
 
     def test_basic_iri_templates(self):
-        """Tests the URI constructed on the basis of Basic Representation
-        """
+        """Tests the URI constructed on the basis of Basic Representation"""
         simplified_response = {
             "@context": "/serverapi/contexts/DroneCollection.jsonld",
             "@id": "/serverapi/DroneCollection/",
             "@type": "DroneCollection",
             "members": [
-                {
-                    "@id": "/serverapi/DroneCollection/1",
-                    "@type": "Drone"
-                },
+                {"@id": "/serverapi/DroneCollection/1", "@type": "Drone"},
             ],
             "search": {
                 "@type": "hydra:IriTemplate",
@@ -352,64 +217,65 @@ class TestAgent(unittest.TestCase):
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "http://schema.org/name",
                         "hydra:required": False,
-                        "hydra:variable": "name"
+                        "hydra:variable": "name",
                     },
                     {
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "pageIndex",
                         "hydra:required": False,
-                        "hydra:variable": "pageIndex"
+                        "hydra:variable": "pageIndex",
                     },
                     {
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "limit",
                         "hydra:required": False,
-                        "hydra:variable": "limit"
+                        "hydra:variable": "limit",
                     },
                     {
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "offset",
                         "hydra:required": False,
-                        "hydra:variable": "offset"
-                    }
+                        "hydra:variable": "offset",
+                    },
                 ],
                 "hydra:template": "/serverapi/(pageIndex, limit, offset)",
-                "hydra:variableRepresentation": "hydra:BasicRepresentation"
+                "hydra:variableRepresentation": "hydra:BasicRepresentation",
             },
-
             "view": {
                 "@id": "/serverapi/DroneCollection?page=1",
                 "@type": "PartialCollectionView",
                 "first": "/serverapi/DroneCollection?page=1",
                 "last": "/serverapi/DroneCollection?page=1",
-                "next": "/serverapi/DroneCollection?page=1"
-            }
+                "next": "/serverapi/DroneCollection?page=1",
+            },
         }
         sample_mapping_object = {
             "name": "Drone1",
             "pageIndex": "1",
             "limit": "10",
-            "offset": "1"
+            "offset": "1",
         }
-        url = urlparse(expand_template(
-            "http://localhost:8080/serverapi/DroneCollection", simplified_response, sample_mapping_object))
+        url = urlparse(
+            expand_template(
+                "http://localhost:8080/serverapi/DroneCollection",
+                simplified_response,
+                sample_mapping_object,
+            )
+        )
         url_should_be = urlparse(
-            "http://localhost:8080/serverapi/DroneCollection?name=Drone1&pageIndex=1&limit=10&offset=1")
+            "http://localhost:8080/serverapi/DroneCollection?name=Drone1&pageIndex=1&limit=10&offset=1"
+        )
 
-        self.assertEqual(sorted(url.query), sorted(url_should_be.query))
+        assert sorted(url.query) == sorted(url_should_be.query)
 
     def test_explicit_iri_templates(self):
-        """Tests the URI constructed on the basis of Basic Representation
-        """
+        """Tests the URI constructed on the basis of Basic Representation"""
         simplified_response = {
             "@context": "/serverapi/contexts/DroneCollection.jsonld",
             "@id": "/serverapi/DroneCollection/",
             "@type": "DroneCollection",
             "members": [
-                {
-                    "@id": "/serverapi/DroneCollection/1",
-                    "@type": "Drone"
-                },
+                {"@id": "/serverapi/DroneCollection/1", "@type": "Drone"},
             ],
             "search": {
                 "@type": "hydra:IriTemplate",
@@ -418,129 +284,103 @@ class TestAgent(unittest.TestCase):
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "http://schema.org/name",
                         "hydra:required": False,
-                        "hydra:variable": "name"
+                        "hydra:variable": "name",
                     },
                     {
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "pageIndex",
                         "hydra:required": False,
-                        "hydra:variable": "pageIndex"
+                        "hydra:variable": "pageIndex",
                     },
                     {
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "limit",
                         "hydra:required": False,
-                        "hydra:variable": "limit"
+                        "hydra:variable": "limit",
                     },
                     {
                         "@type": "hydra:IriTemplateMapping",
                         "hydra:property": "offset",
                         "hydra:required": False,
-                        "hydra:variable": "offset"
-                    }
+                        "hydra:variable": "offset",
+                    },
                 ],
                 "hydra:template": "/serverapi/(pageIndex, limit, offset)",
-                "hydra:variableRepresentation": "hydra:ExplicitRepresentation"
+                "hydra:variableRepresentation": "hydra:ExplicitRepresentation",
             },
             "view": {
                 "@id": "/serverapi/DroneCollection?page=1",
                 "@type": "PartialCollectionView",
                 "first": "/serverapi/DroneCollection?page=1",
                 "last": "/serverapi/DroneCollection?page=1",
-                "next": "/serverapi/DroneCollection?page=1"
-            }
+                "next": "/serverapi/DroneCollection?page=1",
+            },
         }
         sample_mapping_object = {
-            "url_demo": {
-                "@id": "http://www.hydra-cg.com/"
-            },
-            "prop_with_language": {
-                "@language": "en",
-                "@value": "A simple string"
-            },
+            "url_demo": {"@id": "http://www.hydra-cg.com/"},
+            "prop_with_language": {"@language": "en", "@value": "A simple string"},
             "prop_with_type": {
                 "@value": "5.5",
-                "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+                "@type": "http://www.w3.org/2001/XMLSchema#decimal",
             },
-            "str_prop": "A simple string"
+            "str_prop": "A simple string",
         }
-        url = urlparse(expand_template(
-            "http://localhost:8080/serverapi/DroneCollection", simplified_response, sample_mapping_object))
+        url = urlparse(
+            expand_template(
+                "http://localhost:8080/serverapi/DroneCollection",
+                simplified_response,
+                sample_mapping_object,
+            )
+        )
         url_should_be = urlparse(
-            "http://localhost:8080/serverapi/DroneCollection?url_demo=http%3A%2F%2Fwww.hydra-cg.com%2F&prop_with_language=%22A%20simple%20string%22%40en&prop_with_type=%225.5%22%5E%5Ehttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23decimal&str_prop=%22A%20simple%20string%22")
+            "http://localhost:8080/serverapi/DroneCollection?url_demo=http%3A%2F%2Fwww.hydra-cg.com%2F&prop_with_language=%22A%20simple%20string%22%40en&prop_with_type=%225.5%22%5E%5Ehttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23decimal&str_prop=%22A%20simple%20string%22"
+        )
 
-        self.assertEqual(sorted(url.query), sorted(url_should_be.query))
+        assert sorted(url.query) == sorted(url_should_be.query)
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.put')
-    def test_edges(self, put_session_mock, embedded_get_mock):
+    def test_edges(
+        self,
+        put_session_mock,
+        get_session_mock,
+        new_object,
+        state_object,
+        drone_res,
+        mocker,
+    ):
         """Tests to check if all edges are being created properly
         :param put_session_mock: MagicMock object for patching session.put
-        :param embedded_get_mock: MagicMock object for patching session.get
+        :param get_session_mock: MagicMock object for patching session.get
         """
-        new_object = {"@type": "Drone", "DroneState": {
-                      "@type": "State", "Battery": "C1WE92", "Direction": "Q9VV88", "DroneID": "6EBGT5", "Position": "A"
-                      ,"SensorStatus": "335Y8B", "Speed": "IZPSTE"},
-                      "name": "Smart Drone", "model": "Hydra Drone",
-                      "MaxSpeed": "999", "Sensor": "Wind"}
 
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "1"
 
         put_session_mock.return_value.status_code = 201
         put_session_mock.return_value.json.return_value = new_object
-        put_session_mock.return_value.headers = {'Location': new_object_url}
+        put_session_mock.return_value.headers = {"Location": new_object_url}
 
-        state_object = {"@context": "/api/contexts/State.jsonld",
-                        "@id": "/api/State/1", "@type": "State",
-                        "Battery": "sensor Ex", "Direction": "speed Ex",
-                        "DroneID": "sensor Ex", "Position": "model Ex",
-                        "SensorStatus": "sensor Ex", "Speed": "2"}
-        drone_res = {
-                    "@context": "/api/contexts/Drone.jsonld",
-                    "@id": "/api/Drone/1",
-                    "@type": "Drone",
-                    "DroneState": {
-                        "@id": "/api/State/1",
-                        "@type": "State",
-                        "Battery": "C1WE92",
-                        "Direction": "Q9VV88",
-                        "DroneID": "6EBGT5",
-                        "Position": "A",
-                        "SensorStatus": "335Y8B",
-                        "Speed": "IZPSTE"
-                    },
-                    "MaxSpeed": "A3GZ37",
-                    "Sensor": "E7JD5Q",
-                    "model": "HB14CX",
-                    "name": "Priaysnhu"
-        }
-        fake_responses = [Mock(), Mock()]
+        fake_responses = [mocker.Mock(), mocker.Mock()]
         fake_responses[0].json.return_value = drone_res
         fake_responses[0].status_code = 200
         fake_responses[1].json.return_value = state_object
         fake_responses[1].status_code = 200
         # Mocking an object to be used for a property that has an embedded link
-        embedded_get_mock.return_value.status_code = 200
-        embedded_get_mock.side_effect = fake_responses
+        get_session_mock.return_value.status_code = 200
+        get_session_mock.side_effect = fake_responses
         response, new_object_url = self.agent.put(class_url, new_object)
         # Checking if Drone Class has an edge to the Drone Resource
         query = "MATCH (p)-[r]->() WHERE p.type = 'Drone' \
             RETURN type(r)"
         query_result = self.redis_graph.query(query)
-        self.assertEqual(query_result.result_set[0][0], 'has_Drone')
+        assert query_result.result_set[0][0] == "has_Drone"
 
         # Checking if State  has an edge to the State Resource
         query = "MATCH (p)-[r]->() WHERE p.type = 'State' \
             RETURN type(r)"
         query_result = self.redis_graph.query(query)
-        self.assertEqual(query_result.result_set[0][0], 'has_State')
+        assert query_result.result_set[0][0] == "has_State"
 
         # Checking if Drone Resource has an edge to the State Resource
         query = "MATCH (p)-[r]->() WHERE p.type = 'Drone' RETURN type(r)"
         query_result = self.redis_graph.query(query)
-        self.assertEqual(query_result.result_set[1][0], 'has_State')
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert query_result.result_set[1][0] == "has_State"

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -3,6 +3,8 @@ from hydra_agent.agent import Agent
 from hydra_agent.helpers import expand_template
 from urllib.parse import urlparse
 
+from hydra_agent.tests.conftest import constants
+
 
 @pytest.mark.usefixtures("setup_agent_for_tests")
 class TestAgent:
@@ -20,7 +22,7 @@ class TestAgent:
         """Tests get method from the Agent with URL"""
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
-        response = self.agent.get(self.entrypoint_url + "State/1")
+        response = self.agent.get(self.entrypoint_url + "/State/1")
 
         assert response == state_object
 
@@ -29,7 +31,7 @@ class TestAgent:
 
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
-        response_url = self.agent.get("http://localhost:8080/api/" + "State/1")
+        response_url = self.agent.get(self.entrypoint_url + "/State/1")
 
         response_cached = self.agent.get(
             resource_type="State", filters={"Direction": "North"}, cached_limit=1
@@ -38,7 +40,7 @@ class TestAgent:
         response_cached = response_cached[0]
         assert response_url == response_cached
 
-        response_not_cached = self.agent.get("http://localhost:8080/api/" + "State/1")
+        response_not_cached = self.agent.get(self.entrypoint_url + "/State/1")
         assert response_not_cached == response_cached
 
     def test_get_collection(
@@ -48,7 +50,7 @@ class TestAgent:
 
         new_object = {"@type": "DroneCollection", "members": ["1"]}
 
-        collection_url = "http://localhost:8080/api/DroneCollection/"
+        collection_url = self.entrypoint_url + "/DroneCollection/"
         new_collection_url = collection_url + "1"
 
         put_session_mock.return_value.status_code = 201
@@ -76,7 +78,7 @@ class TestAgent:
     ):
         """Tests put method from the Agent"""
 
-        class_url = "http://localhost:8080/api/Drone/"
+        class_url = self.entrypoint_url + "/Drone/"
         new_object_url = class_url + "1"
 
         put_session_mock.return_value.status_code = 201
@@ -117,7 +119,7 @@ class TestAgent:
         mocker,
     ):
         """Tests post method from the Agent"""
-        class_url = "http://localhost:8080/api/Drone/"
+        class_url = self.entrypoint_url + "/Drone/"
         new_object_url = class_url + "2"
 
         put_session_mock.return_value.status_code = 201
@@ -137,7 +139,7 @@ class TestAgent:
 
         post_session_mock.return_value.status_code = 200
         post_session_mock.return_value.json.return_value = {"msg": "success"}
-        new_object["DroneState"]["@id"] = "/api/State/1"
+        new_object["DroneState"]["@id"] = "/serverapi/State/1"
         new_object["name"] = "Updated Name"
         # Mocking an object to be used for a property that has an embedded link
         response = self.agent.post(new_object_url, new_object)
@@ -160,7 +162,7 @@ class TestAgent:
     ):
         """Tests post method from the Agent"""
 
-        class_url = "http://localhost:8080/api/Drone/"
+        class_url = self.entrypoint_url + "/Drone/"
         new_object_url = class_url + "3"
 
         put_session_mock.return_value.status_code = 201
@@ -334,7 +336,7 @@ class TestAgent:
     ):
         """Tests to check if all edges are being created properly"""
 
-        class_url = "http://localhost:8080/api/Drone/"
+        class_url = self.entrypoint_url + "/Drone/"
         new_object_url = class_url + "1"
 
         put_session_mock.return_value.status_code = 201

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -17,9 +17,7 @@ class TestAgent:
             self.init_agent(constants["entrypoint_url"])
 
     def test_get_url(self, get_session_mock, state_object):
-        """Tests get method from the Agent with URL
-        :param get_session_mock: MagicMock object for patching session.get
-        """
+        """Tests get method from the Agent with URL"""
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
         response = self.agent.get(self.entrypoint_url + "State/1")
@@ -27,9 +25,7 @@ class TestAgent:
         assert response == state_object
 
     def test_get_class_properties(self, get_session_mock, state_object):
-        """Tests get method from the Agent by class name and properties
-        :param get_session_mock: MagicMock object for patching session.get
-        """
+        """Tests get method from the Agent by class name and properties"""
 
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
@@ -48,10 +44,8 @@ class TestAgent:
     def test_get_collection(
         self, get_session_mock, put_session_mock, simplified_collection
     ):
-        """Tests get method from the Agent when fetching collections
-        :param put_session_mock: MagicMock object for patching session.put
-        :param get_session_mock: MagicMock object for patching session.get
-        """
+        """Tests get method from the Agent when fetching collections"""
+
         new_object = {"@type": "DroneCollection", "members": ["1"]}
 
         collection_url = "http://localhost:8080/api/DroneCollection/"
@@ -80,10 +74,8 @@ class TestAgent:
         state_object,
         drone_res,
     ):
-        """Tests put method from the Agent
-        :param put_session_mock: MagicMock object for patching session.put
-        :param get_session_mock: MagicMock object for patching session.get
-        """
+        """Tests put method from the Agent"""
+
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "1"
 
@@ -124,10 +116,7 @@ class TestAgent:
         drone_res,
         mocker,
     ):
-        """Tests post method from the Agent
-        :param put_session_mock: MagicMock object for patching session.put
-        :param post_session_mock: MagicMock object for patching session.post
-        """
+        """Tests post method from the Agent"""
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "2"
 
@@ -169,11 +158,7 @@ class TestAgent:
         state_object,
         drone_res,
     ):
-        """Tests post method from the Agent
-        :param put_session_mock: MagicMock object for patching session.put
-        :param delete_session_mock: MagicMock object to patch session.delete
-        :param get_session_mock: MagicMock object for patching session.get
-        """
+        """Tests post method from the Agent"""
 
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "3"
@@ -347,10 +332,7 @@ class TestAgent:
         drone_res,
         mocker,
     ):
-        """Tests to check if all edges are being created properly
-        :param put_session_mock: MagicMock object for patching session.put
-        :param get_session_mock: MagicMock object for patching session.get
-        """
+        """Tests to check if all edges are being created properly"""
 
         class_url = "http://localhost:8080/api/Drone/"
         new_object_url = class_url + "1"

--- a/hydra_agent/tests/test_examples/hydra_doc_sample.py
+++ b/hydra_agent/tests/test_examples/hydra_doc_sample.py
@@ -58,7 +58,8 @@ doc = {
         "supportedOperation": "hydra:supportedOperation",
         "supportedProperty": "hydra:supportedProperty",
         "title": "hydra:title",
-        "writeable": "hydra:writeable"
+        "writeable": "hydra:writeable",
+        "xsd": "https://www.w3.org/TR/xmlschema-2/#"
     },
     "@id": "http://localhost:8080/api/vocab",
     "@type": "ApiDocumentation",
@@ -67,18 +68,18 @@ doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
-            "@id": "http://localhost:8080/api/vocab#Drone",
+            "@id": "http://localhost:8080/api/vocab?resource=Drone",
             "@type": "hydra:Class",
             "description": "Class for a drone",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/api/vocab#Drone",
+                    "expects": "http://localhost:8080/api/vocab?resource=Drone",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Drone updated",
                             "statusCode": 200,
@@ -91,12 +92,12 @@ doc = {
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/api/vocab#Drone",
+                    "expects": "http://localhost:8080/api/vocab?resource=Drone",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Drone added",
                             "statusCode": 200,
@@ -114,21 +115,21 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Drone not found",
                             "statusCode": 404,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Drone Returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Drone",
+                    "returns": "http://localhost:8080/api/vocab?resource=Drone",
                     "returnsHeader": [],
                     "title": "GetDrone"
                 }
@@ -136,7 +137,7 @@ doc = {
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/api/vocab#State",
+                    "property": "http://localhost:8080/api/vocab?resource=State",
                     "readable": "false",
                     "required": "true",
                     "title": "DroneState",
@@ -178,7 +179,7 @@ doc = {
             "title": "Drone"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#State",
+            "@id": "http://localhost:8080/api/vocab?resource=State",
             "@type": "hydra:Class",
             "description": "Class for drone state objects",
             "supportedOperation": [
@@ -189,21 +190,21 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "State not found",
                             "statusCode": 404,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "State Returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returns": "http://localhost:8080/api/vocab?resource=State",
                     "returnsHeader": [],
                     "title": "GetState"
                 }
@@ -261,7 +262,7 @@ doc = {
             "title": "State"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#Datastream",
+            "@id": "http://localhost:8080/api/vocab?resource=Datastream",
             "@type": "hydra:Class",
             "description": "Class for a datastream entry",
             "supportedOperation": [
@@ -272,32 +273,32 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Data not found",
                             "statusCode": 404,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Data returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                     "returnsHeader": [],
                     "title": "ReadDatastream"
                 },
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Data updated",
                             "statusCode": 200,
@@ -315,7 +316,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Data deleted",
                             "statusCode": 200,
@@ -356,7 +357,7 @@ doc = {
             "title": "Datastream"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#LogEntry",
+            "@id": "http://localhost:8080/api/vocab?resource=LogEntry",
             "@type": "hydra:Class",
             "description": "Class for a log entry",
             "supportedOperation": [
@@ -367,32 +368,32 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Log entry not found",
                             "statusCode": 404,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Log entry returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "returnsHeader": [],
                     "title": "GetLog"
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Log entry created",
                             "statusCode": 201,
@@ -439,7 +440,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/api/vocab#State",
+                    "property": "http://localhost:8080/api/vocab?resource=State",
                     "readable": "false",
                     "required": "false",
                     "title": "State",
@@ -447,7 +448,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/api/vocab#Datastream",
+                    "property": "http://localhost:8080/api/vocab?resource=Datastream",
                     "readable": "false",
                     "required": "false",
                     "title": "Data",
@@ -455,7 +456,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/api/vocab#Command",
+                    "property": "http://localhost:8080/api/vocab?resource=Command",
                     "readable": "false",
                     "required": "false",
                     "title": "Command",
@@ -465,18 +466,18 @@ doc = {
             "title": "LogEntry"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#Area",
+            "@id": "http://localhost:8080/api/vocab?resource=Area",
             "@type": "hydra:Class",
             "description": "Class for Area of Interest of the server",
             "supportedOperation": [
                 {
                     "@type": "http://schema.org/UpdateAction",
-                    "expects": "http://localhost:8080/api/vocab#Area",
+                    "expects": "http://localhost:8080/api/vocab?resource=Area",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Area of interest changed",
                             "statusCode": 200,
@@ -494,21 +495,21 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Area of interest not found",
                             "statusCode": 200,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Area of interest returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Area",
+                    "returns": "http://localhost:8080/api/vocab?resource=Area",
                     "returnsHeader": [],
                     "title": "GetArea"
                 }
@@ -534,7 +535,7 @@ doc = {
             "title": "Area"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#Command",
+            "@id": "http://localhost:8080/api/vocab?resource=Command",
             "@type": "hydra:Class",
             "description": "Class for drone commands",
             "supportedOperation": [
@@ -545,32 +546,32 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Command not found",
                             "statusCode": 404,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Command Returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returns": "http://localhost:8080/api/vocab?resource=Command",
                     "returnsHeader": [],
                     "title": "GetCommand"
                 },
                 {
                     "@type": "http://schema.org/AddAction",
-                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expects": "http://localhost:8080/api/vocab?resource=Command",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Command added",
                             "statusCode": 201,
@@ -588,7 +589,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Command deleted",
                             "statusCode": 201,
@@ -611,7 +612,7 @@ doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://localhost:8080/api/vocab#State",
+                    "property": "http://localhost:8080/api/vocab?resource=State",
                     "readable": "false",
                     "required": "true",
                     "title": "State",
@@ -621,7 +622,7 @@ doc = {
             "title": "Command"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#Message",
+            "@id": "http://localhost:8080/api/vocab?resource=Message",
             "@type": "hydra:Class",
             "description": "Class for messages received by the GUI interface",
             "supportedOperation": [
@@ -632,21 +633,21 @@ doc = {
                     "method": "GET",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Message not found",
                             "statusCode": 200,
                             "title": ""
                         },
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Message returned",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Message",
+                    "returns": "http://localhost:8080/api/vocab?resource=Message",
                     "returnsHeader": [],
                     "title": "GetMessage"
                 },
@@ -657,7 +658,7 @@ doc = {
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "Message deleted",
                             "statusCode": 200,
@@ -707,48 +708,88 @@ doc = {
             "title": "Collection"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#DroneCollection",
-            "@type": "hydra:Class",
-            "description": "A collection of drone",
-            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "@id": "http://localhost:8080/api/vocab?resource=DroneCollection",
+            "@type": "Collection",
+            "description": "A collection of drones",
             "manages": {
-                "object": "http://localhost:8080/api/vocab#Drone",
+                "object": "http://localhost:8080/api/vocab?resource=Drone",
                 "property": "rdfs:type"
             },
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
             "supportedOperation": [
                 {
-                    "@id": "_:drone_collection_retrieve",
+                    "@id": "_:DroneCollection_retrieve",
                     "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all Drone entities",
+                    "description": "Retrieves all the members of DroneCollection",
                     "expects": "null",
-                    "method": "GET",
-                    "returns": "http://localhost:8080/api/vocab#DroneCollection",
                     "expectsHeader": [],
-                    "returnsHeader": [],
-                    "possibleStatus": []
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab?resource=Drone",
+                    "returnsHeader": []
                 },
                 {
-                    "@id": "_:drone_create",
+                    "@id": "_:DroneCollection_create",
                     "@type": "http://schema.org/AddAction",
-                    "description": "Create new Drone entity",
-                    "expects": "http://localhost:8080/api/vocab#Drone",
-                    "method": "PUT",
-                    "returns": "http://localhost:8080/api/vocab#Drone",
+                    "description": "Create new member in DroneCollection",
+                    "expects": "http://localhost:8080/api/vocab?resource=Drone",
                     "expectsHeader": [],
-                    "returnsHeader": [],
+                    "method": "PUT",
                     "possibleStatus": [
                         {
-                            "title": "If the Drone entity was created successfully.",
+                            "@context": "https://www.w3.org/ns/hydra/core",
+                            "@type": "Status",
+                            "description": "A new member in DroneCollection created",
                             "statusCode": 201,
-                            "description": ""
+                            "title": ""
                         }
-                    ]
+                    ],
+                    "returns": "http://localhost:8080/api/vocab?resource=Drone",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:DroneCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  DroneCollection ",
+                    "expects": "http://localhost:8080/api/vocab?resource=Drone",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://www.w3.org/ns/hydra/core",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom DroneCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab?resource=Drone",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:DroneCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of DroneCollection ",
+                    "expects": "http://localhost:8080/api/vocab?resource=Drone",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://www.w3.org/ns/hydra/core",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from DroneCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab?resource=Drone",
+                    "returnsHeader": []
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "description": "The drone",
+                    "description": "The members of DroneCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
                     "readable": "true",
                     "required": "false",
@@ -759,103 +800,11 @@ doc = {
             "title": "DroneCollection"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#MessageCollection",
-            "@type": "Collection",
-            "description": "A collection of messages",
-            "manages": {
-                "object": "http://localhost:8080/api/vocab#Message",
-                "property": "rdfs:type"
-            },
-            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
-            "supportedOperation": [
-                {
-                    "@id": "_:MessageCollection_retrieve",
-                    "@type": "http://schema.org/FindAction",
-                    "description": "Retrieves all the members of MessageCollection",
-                    "expects": "null",
-                    "expectsHeader": [],
-                    "method": "GET",
-                    "possibleStatus": [],
-                    "returns": "http://localhost:8080/api/vocab#Message",
-                    "returnsHeader": []
-                },
-                {
-                    "@id": "_:MessageCollection_create",
-                    "@type": "http://schema.org/AddAction",
-                    "description": "Create new member in MessageCollection",
-                    "expects": "http://localhost:8080/api/vocab#Message",
-                    "expectsHeader": [],
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "A new member in MessageCollection created",
-                            "statusCode": 201,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/api/vocab#Message",
-                    "returnsHeader": []
-                },
-                {
-                    "@id": "_:MessageCollection_update",
-                    "@type": "http://schema.org/UpdateAction",
-                    "description": "Update member of  MessageCollection ",
-                    "expects": "http://localhost:8080/api/vocab#Message",
-                    "expectsHeader": [],
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "If the entity was updatedfrom MessageCollection.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/api/vocab#Message",
-                    "returnsHeader": []
-                },
-                {
-                    "@id": "_:MessageCollection_delete",
-                    "@type": "http://schema.org/DeleteAction",
-                    "description": "Delete member of MessageCollection ",
-                    "expects": "http://localhost:8080/api/vocab#Message",
-                    "expectsHeader": [],
-                    "method": "DELETE",
-                    "possibleStatus": [
-                        {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-                            "@type": "Status",
-                            "description": "If entity was deletedsuccessfully from MessageCollection.",
-                            "statusCode": 200,
-                            "title": ""
-                        }
-                    ],
-                    "returns": "http://localhost:8080/api/vocab#Message",
-                    "returnsHeader": []
-                }
-            ],
-            "supportedProperty": [
-                {
-                    "@type": "SupportedProperty",
-                    "description": "The members of MessageCollection",
-                    "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "false",
-                    "required": "false",
-                    "title": "members",
-                    "writeable": "false"
-                }
-            ],
-            "title": "MessageCollection"
-        },
-        {
-            "@id": "http://localhost:8080/api/vocab#StateCollection",
+            "@id": "http://localhost:8080/api/vocab?resource=StateCollection",
             "@type": "Collection",
             "description": "A collection of states",
             "manages": {
-                "object": "http://localhost:8080/api/vocab#State",
+                "object": "http://localhost:8080/api/vocab?resource=State",
                 "property": "rdfs:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
@@ -868,64 +817,64 @@ doc = {
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returns": "http://localhost:8080/api/vocab?resource=State",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:StateCollection_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in StateCollection",
-                    "expects": "http://localhost:8080/api/vocab#State",
+                    "expects": "http://localhost:8080/api/vocab?resource=State",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in StateCollection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returns": "http://localhost:8080/api/vocab?resource=State",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:StateCollection_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  StateCollection ",
-                    "expects": "http://localhost:8080/api/vocab#State",
+                    "expects": "http://localhost:8080/api/vocab?resource=State",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom StateCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returns": "http://localhost:8080/api/vocab?resource=State",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:StateCollection_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of StateCollection ",
-                    "expects": "http://localhost:8080/api/vocab#State",
+                    "expects": "http://localhost:8080/api/vocab?resource=State",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from StateCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#State",
+                    "returns": "http://localhost:8080/api/vocab?resource=State",
                     "returnsHeader": []
                 }
             ],
@@ -934,20 +883,20 @@ doc = {
                     "@type": "SupportedProperty",
                     "description": "The members of StateCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "false",
+                    "readable": "true",
                     "required": "false",
                     "title": "members",
-                    "writeable": "false"
+                    "writeable": "true"
                 }
             ],
             "title": "StateCollection"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#DatastreamCollection",
+            "@id": "http://localhost:8080/api/vocab?resource=DatastreamCollection",
             "@type": "Collection",
             "description": "A collection of datastream",
             "manages": {
-                "object": "http://localhost:8080/api/vocab#Datastream",
+                "object": "http://localhost:8080/api/vocab?resource=Datastream",
                 "property": "rdfs:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
@@ -960,64 +909,64 @@ doc = {
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:DatastreamCollection_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in DatastreamCollection",
-                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in DatastreamCollection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:DatastreamCollection_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  DatastreamCollection ",
-                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom DatastreamCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:DatastreamCollection_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of DatastreamCollection ",
-                    "expects": "http://localhost:8080/api/vocab#Datastream",
+                    "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from DatastreamCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Datastream",
+                    "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                     "returnsHeader": []
                 }
             ],
@@ -1026,20 +975,20 @@ doc = {
                     "@type": "SupportedProperty",
                     "description": "The members of DatastreamCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "false",
+                    "readable": "true",
                     "required": "false",
                     "title": "members",
-                    "writeable": "false"
+                    "writeable": "true"
                 }
             ],
             "title": "DatastreamCollection"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#LogEntryCollection",
+            "@id": "http://localhost:8080/api/vocab?resource=LogEntryCollection",
             "@type": "Collection",
             "description": "A collection of logs",
             "manages": {
-                "object": "http://localhost:8080/api/vocab#LogEntry",
+                "object": "http://localhost:8080/api/vocab?resource=LogEntry",
                 "property": "rdfs:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
@@ -1052,64 +1001,64 @@ doc = {
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:LogEntryCollection_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in LogEntryCollection",
-                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in LogEntryCollection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:LogEntryCollection_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  LogEntryCollection ",
-                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom LogEntryCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:LogEntryCollection_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of LogEntryCollection ",
-                    "expects": "http://localhost:8080/api/vocab#LogEntry",
+                    "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from LogEntryCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#LogEntry",
+                    "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                     "returnsHeader": []
                 }
             ],
@@ -1118,20 +1067,20 @@ doc = {
                     "@type": "SupportedProperty",
                     "description": "The members of LogEntryCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "false",
+                    "readable": "true",
                     "required": "false",
                     "title": "members",
-                    "writeable": "false"
+                    "writeable": "true"
                 }
             ],
             "title": "LogEntryCollection"
         },
         {
-            "@id": "http://localhost:8080/api/vocab#CommandCollection",
+            "@id": "http://localhost:8080/api/vocab?resource=CommandCollection",
             "@type": "Collection",
             "description": "A collection of commands",
             "manages": {
-                "object": "http://localhost:8080/api/vocab#Command",
+                "object": "http://localhost:8080/api/vocab?resource=Command",
                 "property": "rdfs:type"
             },
             "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
@@ -1144,64 +1093,64 @@ doc = {
                     "expectsHeader": [],
                     "method": "GET",
                     "possibleStatus": [],
-                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returns": "http://localhost:8080/api/vocab?resource=Command",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CommandCollection_create",
                     "@type": "http://schema.org/AddAction",
                     "description": "Create new member in CommandCollection",
-                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expects": "http://localhost:8080/api/vocab?resource=Command",
                     "expectsHeader": [],
                     "method": "PUT",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "A new member in CommandCollection created",
                             "statusCode": 201,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returns": "http://localhost:8080/api/vocab?resource=Command",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CommandCollection_update",
                     "@type": "http://schema.org/UpdateAction",
                     "description": "Update member of  CommandCollection ",
-                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expects": "http://localhost:8080/api/vocab?resource=Command",
                     "expectsHeader": [],
                     "method": "POST",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If the entity was updatedfrom CommandCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returns": "http://localhost:8080/api/vocab?resource=Command",
                     "returnsHeader": []
                 },
                 {
                     "@id": "_:CommandCollection_delete",
                     "@type": "http://schema.org/DeleteAction",
                     "description": "Delete member of CommandCollection ",
-                    "expects": "http://localhost:8080/api/vocab#Command",
+                    "expects": "http://localhost:8080/api/vocab?resource=Command",
                     "expectsHeader": [],
                     "method": "DELETE",
                     "possibleStatus": [
                         {
-                            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                            "@context": "https://www.w3.org/ns/hydra/core",
                             "@type": "Status",
                             "description": "If entity was deletedsuccessfully from CommandCollection.",
                             "statusCode": 200,
                             "title": ""
                         }
                     ],
-                    "returns": "http://localhost:8080/api/vocab#Command",
+                    "returns": "http://localhost:8080/api/vocab?resource=Command",
                     "returnsHeader": []
                 }
             ],
@@ -1210,13 +1159,105 @@ doc = {
                     "@type": "SupportedProperty",
                     "description": "The members of CommandCollection",
                     "property": "http://www.w3.org/ns/hydra/core#member",
-                    "readable": "false",
+                    "readable": "true",
                     "required": "false",
                     "title": "members",
-                    "writeable": "false"
+                    "writeable": "true"
                 }
             ],
             "title": "CommandCollection"
+        },
+        {
+            "@id": "http://localhost:8080/api/vocab?resource=MessageCollection",
+            "@type": "Collection",
+            "description": "A collection of messages",
+            "manages": {
+                "object": "http://localhost:8080/api/vocab?resource=Message",
+                "property": "rdfs:type"
+            },
+            "subClassOf": "http://www.w3.org/ns/hydra/core#Collection",
+            "supportedOperation": [
+                {
+                    "@id": "_:MessageCollection_retrieve",
+                    "@type": "http://schema.org/FindAction",
+                    "description": "Retrieves all the members of MessageCollection",
+                    "expects": "null",
+                    "expectsHeader": [],
+                    "method": "GET",
+                    "possibleStatus": [],
+                    "returns": "http://localhost:8080/api/vocab?resource=Message",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:MessageCollection_create",
+                    "@type": "http://schema.org/AddAction",
+                    "description": "Create new member in MessageCollection",
+                    "expects": "http://localhost:8080/api/vocab?resource=Message",
+                    "expectsHeader": [],
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://www.w3.org/ns/hydra/core",
+                            "@type": "Status",
+                            "description": "A new member in MessageCollection created",
+                            "statusCode": 201,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab?resource=Message",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:MessageCollection_update",
+                    "@type": "http://schema.org/UpdateAction",
+                    "description": "Update member of  MessageCollection ",
+                    "expects": "http://localhost:8080/api/vocab?resource=Message",
+                    "expectsHeader": [],
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://www.w3.org/ns/hydra/core",
+                            "@type": "Status",
+                            "description": "If the entity was updatedfrom MessageCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab?resource=Message",
+                    "returnsHeader": []
+                },
+                {
+                    "@id": "_:MessageCollection_delete",
+                    "@type": "http://schema.org/DeleteAction",
+                    "description": "Delete member of MessageCollection ",
+                    "expects": "http://localhost:8080/api/vocab?resource=Message",
+                    "expectsHeader": [],
+                    "method": "DELETE",
+                    "possibleStatus": [
+                        {
+                            "@context": "https://www.w3.org/ns/hydra/core",
+                            "@type": "Status",
+                            "description": "If entity was deletedsuccessfully from MessageCollection.",
+                            "statusCode": 200,
+                            "title": ""
+                        }
+                    ],
+                    "returns": "http://localhost:8080/api/vocab?resource=Message",
+                    "returnsHeader": []
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "description": "The members of MessageCollection",
+                    "property": "http://www.w3.org/ns/hydra/core#member",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "members",
+                    "writeable": "true"
+                }
+            ],
+            "title": "MessageCollection"
         },
         {
             "@id": "http://localhost:8080/api#EntryPoint",
@@ -1240,24 +1281,24 @@ doc = {
                     "hydra:description": "The Drone Class",
                     "hydra:title": "drone",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Drone",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/Drone",
                         "@type": "hydra:Link",
                         "description": "Class for a drone",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "Drone",
-                        "range": "http://localhost:8080/api/vocab#Drone",
+                        "range": "http://localhost:8080/api/vocab?resource=Drone",
                         "supportedOperation": [
                             {
                                 "@id": "submitdrone",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "http://localhost:8080/api/vocab#Drone",
+                                "expects": "http://localhost:8080/api/vocab?resource=Drone",
                                 "expectsHeader": [],
                                 "label": "SubmitDrone",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Drone updated",
                                         "statusCode": 200,
@@ -1271,13 +1312,13 @@ doc = {
                                 "@id": "createdrone",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "null",
-                                "expects": "http://localhost:8080/api/vocab#Drone",
+                                "expects": "http://localhost:8080/api/vocab?resource=Drone",
                                 "expectsHeader": [],
                                 "label": "CreateDrone",
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Drone added",
                                         "statusCode": 200,
@@ -1297,21 +1338,21 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Drone not found",
                                         "statusCode": 404,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Drone Returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Drone",
+                                "returns": "http://localhost:8080/api/vocab?resource=Drone",
                                 "returnsHeader": []
                             }
                         ]
@@ -1324,12 +1365,12 @@ doc = {
                     "hydra:description": "The State Class",
                     "hydra:title": "state",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/State",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/State",
                         "@type": "hydra:Link",
                         "description": "Class for drone state objects",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "State",
-                        "range": "http://localhost:8080/api/vocab#State",
+                        "range": "http://localhost:8080/api/vocab?resource=State",
                         "supportedOperation": [
                             {
                                 "@id": "getstate",
@@ -1341,21 +1382,21 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "State not found",
                                         "statusCode": 404,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "State Returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returns": "http://localhost:8080/api/vocab?resource=State",
                                 "returnsHeader": []
                             }
                         ]
@@ -1368,12 +1409,12 @@ doc = {
                     "hydra:description": "The Datastream Class",
                     "hydra:title": "datastream",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Datastream",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/Datastream",
                         "@type": "hydra:Link",
                         "description": "Class for a datastream entry",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "Datastream",
-                        "range": "http://localhost:8080/api/vocab#Datastream",
+                        "range": "http://localhost:8080/api/vocab?resource=Datastream",
                         "supportedOperation": [
                             {
                                 "@id": "readdatastream",
@@ -1385,34 +1426,34 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Data not found",
                                         "statusCode": 404,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Data returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "updatedatastream",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "expectsHeader": [],
                                 "label": "UpdateDatastream",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Data updated",
                                         "statusCode": 200,
@@ -1432,7 +1473,7 @@ doc = {
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Data deleted",
                                         "statusCode": 200,
@@ -1452,12 +1493,12 @@ doc = {
                     "hydra:description": "The LogEntry Class",
                     "hydra:title": "logentry",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/LogEntry",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/LogEntry",
                         "@type": "hydra:Link",
                         "description": "Class for a log entry",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "LogEntry",
-                        "range": "http://localhost:8080/api/vocab#LogEntry",
+                        "range": "http://localhost:8080/api/vocab?resource=LogEntry",
                         "supportedOperation": [
                             {
                                 "@id": "getlog",
@@ -1469,34 +1510,34 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Log entry not found",
                                         "statusCode": 404,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Log entry returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "addlog",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "null",
-                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "expectsHeader": [],
                                 "label": "AddLog",
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Log entry created",
                                         "statusCode": 201,
@@ -1516,24 +1557,24 @@ doc = {
                     "hydra:description": "The Area Class",
                     "hydra:title": "area",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Area",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/Area",
                         "@type": "hydra:Link",
                         "description": "Class for Area of Interest of the server",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "Area",
-                        "range": "http://localhost:8080/api/vocab#Area",
+                        "range": "http://localhost:8080/api/vocab?resource=Area",
                         "supportedOperation": [
                             {
                                 "@id": "updatearea",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "null",
-                                "expects": "http://localhost:8080/api/vocab#Area",
+                                "expects": "http://localhost:8080/api/vocab?resource=Area",
                                 "expectsHeader": [],
                                 "label": "UpdateArea",
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Area of interest changed",
                                         "statusCode": 200,
@@ -1553,21 +1594,21 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Area of interest not found",
                                         "statusCode": 200,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Area of interest returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Area",
+                                "returns": "http://localhost:8080/api/vocab?resource=Area",
                                 "returnsHeader": []
                             }
                         ]
@@ -1580,12 +1621,12 @@ doc = {
                     "hydra:description": "The Command Class",
                     "hydra:title": "command",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Command",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/Command",
                         "@type": "hydra:Link",
                         "description": "Class for drone commands",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "Command",
-                        "range": "http://localhost:8080/api/vocab#Command",
+                        "range": "http://localhost:8080/api/vocab?resource=Command",
                         "supportedOperation": [
                             {
                                 "@id": "getcommand",
@@ -1597,34 +1638,34 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Command not found",
                                         "statusCode": 404,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Command Returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returns": "http://localhost:8080/api/vocab?resource=Command",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "addcommand",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "null",
-                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expects": "http://localhost:8080/api/vocab?resource=Command",
                                 "expectsHeader": [],
                                 "label": "AddCommand",
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Command added",
                                         "statusCode": 201,
@@ -1644,7 +1685,7 @@ doc = {
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Command deleted",
                                         "statusCode": 201,
@@ -1664,12 +1705,12 @@ doc = {
                     "hydra:description": "The Message Class",
                     "hydra:title": "message",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/Message",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/Message",
                         "@type": "hydra:Link",
                         "description": "Class for messages received by the GUI interface",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "Message",
-                        "range": "http://localhost:8080/api/vocab#Message",
+                        "range": "http://localhost:8080/api/vocab?resource=Message",
                         "supportedOperation": [
                             {
                                 "@id": "getmessage",
@@ -1681,21 +1722,21 @@ doc = {
                                 "method": "GET",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Message not found",
                                         "statusCode": 200,
                                         "title": ""
                                     },
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Message returned",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returns": "http://localhost:8080/api/vocab?resource=Message",
                                 "returnsHeader": []
                             },
                             {
@@ -1708,7 +1749,7 @@ doc = {
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "Message deleted",
                                         "statusCode": 200,
@@ -1728,128 +1769,83 @@ doc = {
                     "hydra:description": "The DroneCollection collection",
                     "hydra:title": "dronecollection",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/DroneCollection",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/DroneCollection",
                         "@type": "hydra:Link",
                         "description": "The DroneCollection collection",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "DroneCollection",
-                        "range": "http://localhost:8080/api/vocab#DroneCollection",
-                        "supportedOperation": [
-                            {
-                                "@id": "_:drone_collection_retrieve",
-                                "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all Drone entities",
-                                "expects": "null",
-                                "method": "GET",
-                                "returns": "http://localhost:8080/api/vocab#DroneCollection",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": []
-                            },
-                            {
-                                "@id": "_:drone_create",
-                                "@type": "http://schema.org/AddAction",
-                                "description": "Create new Drone entity",
-                                "expects": "http://localhost:8080/api/vocab#Drone",
-                                "method": "PUT",
-                                "returns": "http://localhost:8080/api/vocab#Drone",
-                                "expectsHeader": [],
-                                "returnsHeader": [],
-                                "possibleStatus": [
-                                    {
-                                        "title": "If the Drone entity was created successfully.",
-                                        "statusCode": 201,
-                                        "description": ""
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "readable": "true",
-                    "required": "null",
-                    "writeable": "false"
-                },
-                {
-                    "hydra:description": "The MessageCollection collection",
-                    "hydra:title": "messagecollection",
-                    "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/MessageCollection",
-                        "@type": "hydra:Link",
-                        "description": "The MessageCollection collection",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
-                        "label": "MessageCollection",
                         "manages": {
-                            "object": "http://localhost:8080/api/vocab#Message",
+                            "object": "http://localhost:8080/api/vocab?resource=Drone",
                             "property": "rdfs:type"
                         },
-                        "range": "http://localhost:8080/api/vocab#MessageCollection",
+                        "range": "http://localhost:8080/api/vocab?resource=DroneCollection",
                         "supportedOperation": [
                             {
-                                "@id": "_:messagecollection_retrieve",
+                                "@id": "_:dronecollection_retrieve",
                                 "@type": "http://schema.org/FindAction",
-                                "description": "Retrieves all the members of MessageCollection",
+                                "description": "Retrieves all the members of DroneCollection",
                                 "expects": "null",
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returns": "http://localhost:8080/api/vocab?resource=Drone",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:messagecollection_create",
+                                "@id": "_:dronecollection_create",
                                 "@type": "http://schema.org/AddAction",
-                                "description": "Create new member in MessageCollection",
-                                "expects": "http://localhost:8080/api/vocab#Message",
+                                "description": "Create new member in DroneCollection",
+                                "expects": "http://localhost:8080/api/vocab?resource=Drone",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
-                                        "description": "A new member in MessageCollection created",
+                                        "description": "A new member in DroneCollection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returns": "http://localhost:8080/api/vocab?resource=Drone",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:messagecollection_update",
+                                "@id": "_:dronecollection_update",
                                 "@type": "http://schema.org/UpdateAction",
-                                "description": "Update member of  MessageCollection ",
-                                "expects": "http://localhost:8080/api/vocab#Message",
+                                "description": "Update member of  DroneCollection ",
+                                "expects": "http://localhost:8080/api/vocab?resource=Drone",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
-                                        "description": "If the entity was updatedfrom MessageCollection.",
+                                        "description": "If the entity was updatedfrom DroneCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returns": "http://localhost:8080/api/vocab?resource=Drone",
                                 "returnsHeader": []
                             },
                             {
-                                "@id": "_:messagecollection_delete",
+                                "@id": "_:dronecollection_delete",
                                 "@type": "http://schema.org/DeleteAction",
-                                "description": "Delete member of MessageCollection ",
-                                "expects": "http://localhost:8080/api/vocab#Message",
+                                "description": "Delete member of DroneCollection ",
+                                "expects": "http://localhost:8080/api/vocab?resource=Drone",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
-                                        "description": "If entity was deletedsuccessfully from MessageCollection.",
+                                        "description": "If entity was deletedsuccessfully from DroneCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Message",
+                                "returns": "http://localhost:8080/api/vocab?resource=Drone",
                                 "returnsHeader": []
                             }
                         ]
@@ -1862,16 +1858,16 @@ doc = {
                     "hydra:description": "The StateCollection collection",
                     "hydra:title": "statecollection",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/StateCollection",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/StateCollection",
                         "@type": "hydra:Link",
                         "description": "The StateCollection collection",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "StateCollection",
                         "manages": {
-                            "object": "http://localhost:8080/api/vocab#State",
+                            "object": "http://localhost:8080/api/vocab?resource=State",
                             "property": "rdfs:type"
                         },
-                        "range": "http://localhost:8080/api/vocab#StateCollection",
+                        "range": "http://localhost:8080/api/vocab?resource=StateCollection",
                         "supportedOperation": [
                             {
                                 "@id": "_:statecollection_retrieve",
@@ -1881,64 +1877,64 @@ doc = {
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returns": "http://localhost:8080/api/vocab?resource=State",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:statecollection_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in StateCollection",
-                                "expects": "http://localhost:8080/api/vocab#State",
+                                "expects": "http://localhost:8080/api/vocab?resource=State",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in StateCollection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returns": "http://localhost:8080/api/vocab?resource=State",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:statecollection_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  StateCollection ",
-                                "expects": "http://localhost:8080/api/vocab#State",
+                                "expects": "http://localhost:8080/api/vocab?resource=State",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom StateCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returns": "http://localhost:8080/api/vocab?resource=State",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:statecollection_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of StateCollection ",
-                                "expects": "http://localhost:8080/api/vocab#State",
+                                "expects": "http://localhost:8080/api/vocab?resource=State",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from StateCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#State",
+                                "returns": "http://localhost:8080/api/vocab?resource=State",
                                 "returnsHeader": []
                             }
                         ]
@@ -1951,16 +1947,16 @@ doc = {
                     "hydra:description": "The DatastreamCollection collection",
                     "hydra:title": "datastreamcollection",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/DatastreamCollection",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/DatastreamCollection",
                         "@type": "hydra:Link",
                         "description": "The DatastreamCollection collection",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "DatastreamCollection",
                         "manages": {
-                            "object": "http://localhost:8080/api/vocab#Datastream",
+                            "object": "http://localhost:8080/api/vocab?resource=Datastream",
                             "property": "rdfs:type"
                         },
-                        "range": "http://localhost:8080/api/vocab#DatastreamCollection",
+                        "range": "http://localhost:8080/api/vocab?resource=DatastreamCollection",
                         "supportedOperation": [
                             {
                                 "@id": "_:datastreamcollection_retrieve",
@@ -1970,64 +1966,64 @@ doc = {
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:datastreamcollection_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in DatastreamCollection",
-                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in DatastreamCollection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:datastreamcollection_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  DatastreamCollection ",
-                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom DatastreamCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:datastreamcollection_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of DatastreamCollection ",
-                                "expects": "http://localhost:8080/api/vocab#Datastream",
+                                "expects": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from DatastreamCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Datastream",
+                                "returns": "http://localhost:8080/api/vocab?resource=Datastream",
                                 "returnsHeader": []
                             }
                         ]
@@ -2040,16 +2036,16 @@ doc = {
                     "hydra:description": "The LogEntryCollection collection",
                     "hydra:title": "logentrycollection",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/LogEntryCollection",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/LogEntryCollection",
                         "@type": "hydra:Link",
                         "description": "The LogEntryCollection collection",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "LogEntryCollection",
                         "manages": {
-                            "object": "http://localhost:8080/api/vocab#LogEntry",
+                            "object": "http://localhost:8080/api/vocab?resource=LogEntry",
                             "property": "rdfs:type"
                         },
-                        "range": "http://localhost:8080/api/vocab#LogEntryCollection",
+                        "range": "http://localhost:8080/api/vocab?resource=LogEntryCollection",
                         "supportedOperation": [
                             {
                                 "@id": "_:logentrycollection_retrieve",
@@ -2059,64 +2055,64 @@ doc = {
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:logentrycollection_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in LogEntryCollection",
-                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in LogEntryCollection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:logentrycollection_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  LogEntryCollection ",
-                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom LogEntryCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:logentrycollection_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of LogEntryCollection ",
-                                "expects": "http://localhost:8080/api/vocab#LogEntry",
+                                "expects": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from LogEntryCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#LogEntry",
+                                "returns": "http://localhost:8080/api/vocab?resource=LogEntry",
                                 "returnsHeader": []
                             }
                         ]
@@ -2129,16 +2125,16 @@ doc = {
                     "hydra:description": "The CommandCollection collection",
                     "hydra:title": "commandcollection",
                     "property": {
-                        "@id": "http://localhost:8080/api/vocab#EntryPoint/CommandCollection",
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/CommandCollection",
                         "@type": "hydra:Link",
                         "description": "The CommandCollection collection",
-                        "domain": "http://localhost:8080/api/vocab#EntryPoint",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
                         "label": "CommandCollection",
                         "manages": {
-                            "object": "http://localhost:8080/api/vocab#Command",
+                            "object": "http://localhost:8080/api/vocab?resource=Command",
                             "property": "rdfs:type"
                         },
-                        "range": "http://localhost:8080/api/vocab#CommandCollection",
+                        "range": "http://localhost:8080/api/vocab?resource=CommandCollection",
                         "supportedOperation": [
                             {
                                 "@id": "_:commandcollection_retrieve",
@@ -2148,64 +2144,153 @@ doc = {
                                 "expectsHeader": [],
                                 "method": "GET",
                                 "possibleStatus": [],
-                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returns": "http://localhost:8080/api/vocab?resource=Command",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:commandcollection_create",
                                 "@type": "http://schema.org/AddAction",
                                 "description": "Create new member in CommandCollection",
-                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expects": "http://localhost:8080/api/vocab?resource=Command",
                                 "expectsHeader": [],
                                 "method": "PUT",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "A new member in CommandCollection created",
                                         "statusCode": 201,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returns": "http://localhost:8080/api/vocab?resource=Command",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:commandcollection_update",
                                 "@type": "http://schema.org/UpdateAction",
                                 "description": "Update member of  CommandCollection ",
-                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expects": "http://localhost:8080/api/vocab?resource=Command",
                                 "expectsHeader": [],
                                 "method": "POST",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If the entity was updatedfrom CommandCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returns": "http://localhost:8080/api/vocab?resource=Command",
                                 "returnsHeader": []
                             },
                             {
                                 "@id": "_:commandcollection_delete",
                                 "@type": "http://schema.org/DeleteAction",
                                 "description": "Delete member of CommandCollection ",
-                                "expects": "http://localhost:8080/api/vocab#Command",
+                                "expects": "http://localhost:8080/api/vocab?resource=Command",
                                 "expectsHeader": [],
                                 "method": "DELETE",
                                 "possibleStatus": [
                                     {
-                                        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+                                        "@context": "https://www.w3.org/ns/hydra/core",
                                         "@type": "Status",
                                         "description": "If entity was deletedsuccessfully from CommandCollection.",
                                         "statusCode": 200,
                                         "title": ""
                                     }
                                 ],
-                                "returns": "http://localhost:8080/api/vocab#Command",
+                                "returns": "http://localhost:8080/api/vocab?resource=Command",
+                                "returnsHeader": []
+                            }
+                        ]
+                    },
+                    "readable": "true",
+                    "required": "null",
+                    "writeable": "false"
+                },
+                {
+                    "hydra:description": "The MessageCollection collection",
+                    "hydra:title": "messagecollection",
+                    "property": {
+                        "@id": "http://localhost:8080/api/vocab?resource=EntryPoint/MessageCollection",
+                        "@type": "hydra:Link",
+                        "description": "The MessageCollection collection",
+                        "domain": "http://localhost:8080/api/vocab?resource=EntryPoint",
+                        "label": "MessageCollection",
+                        "manages": {
+                            "object": "http://localhost:8080/api/vocab?resource=Message",
+                            "property": "rdfs:type"
+                        },
+                        "range": "http://localhost:8080/api/vocab?resource=MessageCollection",
+                        "supportedOperation": [
+                            {
+                                "@id": "_:messagecollection_retrieve",
+                                "@type": "http://schema.org/FindAction",
+                                "description": "Retrieves all the members of MessageCollection",
+                                "expects": "null",
+                                "expectsHeader": [],
+                                "method": "GET",
+                                "possibleStatus": [],
+                                "returns": "http://localhost:8080/api/vocab?resource=Message",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:messagecollection_create",
+                                "@type": "http://schema.org/AddAction",
+                                "description": "Create new member in MessageCollection",
+                                "expects": "http://localhost:8080/api/vocab?resource=Message",
+                                "expectsHeader": [],
+                                "method": "PUT",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://www.w3.org/ns/hydra/core",
+                                        "@type": "Status",
+                                        "description": "A new member in MessageCollection created",
+                                        "statusCode": 201,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab?resource=Message",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:messagecollection_update",
+                                "@type": "http://schema.org/UpdateAction",
+                                "description": "Update member of  MessageCollection ",
+                                "expects": "http://localhost:8080/api/vocab?resource=Message",
+                                "expectsHeader": [],
+                                "method": "POST",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://www.w3.org/ns/hydra/core",
+                                        "@type": "Status",
+                                        "description": "If the entity was updatedfrom MessageCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab?resource=Message",
+                                "returnsHeader": []
+                            },
+                            {
+                                "@id": "_:messagecollection_delete",
+                                "@type": "http://schema.org/DeleteAction",
+                                "description": "Delete member of MessageCollection ",
+                                "expects": "http://localhost:8080/api/vocab?resource=Message",
+                                "expectsHeader": [],
+                                "method": "DELETE",
+                                "possibleStatus": [
+                                    {
+                                        "@context": "https://www.w3.org/ns/hydra/core",
+                                        "@type": "Status",
+                                        "description": "If entity was deletedsuccessfully from MessageCollection.",
+                                        "statusCode": 200,
+                                        "title": ""
+                                    }
+                                ],
+                                "returns": "http://localhost:8080/api/vocab?resource=Message",
                                 "returnsHeader": []
                             }
                         ]
@@ -2220,4 +2305,3 @@ doc = {
     ],
     "title": "API Doc for the server side API"
 }
-

--- a/hydra_agent/tests/test_redis.py
+++ b/hydra_agent/tests/test_redis.py
@@ -1,91 +1,47 @@
-import unittest
 import redis
-from unittest.mock import MagicMock
+import pytest
+from pytest_mock import mocker
 
 
-class Tests:
-    def entry_point(self):
+@pytest.mark.usefixtures("init_db_for_redis_tests")
+class TestRedisStructure:
+    def test_entrypoint(self, redis_reply, redis_db_execute_command_query):
         """Test for testing the data stored in entrypoint endpoint.
         `redis_reply` is data which will get from redis_db_0 on `query` execution.
         """
-        print("testing entrypoint with db=0 ...")
-        query = ('GRAPH.QUERY','apigraph', "MATCH (p:id) RETURN p")
-        redis_db = redis.StrictRedis(host='localhost', port=6379, db=0)
-
-        redis_reply = [[[b'p.url', b'p.id', b'p.supportedOperation'], [b'http://localhost:8080/api', b'vocab:Entrypoint', b'GET']], [b'Query internal execution time: 0.071272 milliseconds']]
-
-        redis_db_execute_command_query = MagicMock(return_value = redis_reply)        
+        query = ("GRAPH.QUERY", "apigraph", "MATCH (p:id) RETURN p")
         property_list = redis_reply[0][0]
-        if (b"p.id" in property_list and
-                b"p.url" in property_list and
-                b"p.supportedOperation" in property_list):
-            return True
-        else:
-            return False
 
-    def collection_endpoints(self):
-        """Test for testing the data stored in collection endpoints
+        assert (
+            b"p.id" in property_list
+            and b"p.url" in property_list
+            and b"p.supportedOperation" in property_list
+        ) == True
+
+    def test_collectionEndpoints(self, redis_reply, redis_db_execute_command_query):
+        """
+        Test for testing the data stored in collection endpoints
         `redis_reply` is data which will get from redis_db_0 on `query` execution.
         """
-        print("testing collection endpoints with db=0 ...")
-        query = ('GRAPH.QUERY','apigraph', "MATCH (p:collection) RETURN p")
-        redis_db = redis.StrictRedis(host='localhost', port=6379, db=0)
-
-        redis_reply = [[[b'p.id', b'p.operations', b'p.type'], [b'vocab:EntryPoint/HttpApiLogCollection', b"['GET', 'PUT']", b'HttpApiLogCollection'], [b'vocab:EntryPoint/AnomalyCollection', b"['GET', 'PUT']", b'AnomalyCollection'], [b'vocab:EntryPoint/CommandCollection', b"['GET', 'PUT']", b'CommandCollection'], [b'vocab:EntryPoint/ControllerLogCollection', b"['GET', 'PUT']", b'ControllerLogCollection'], [b'vocab:EntryPoint/DatastreamCollection', b"['GET', 'PUT']", b'DatastreamCollection'], [b'vocab:EntryPoint/MessageCollection', b"['GET', 'PUT']", b'MessageCollection'], [b'vocab:EntryPoint/DroneLogCollection', b"['GET', 'PUT']", b'DroneLogCollection'], [b'vocab:EntryPoint/DroneCollection', b"['GET', 'PUT']", b'DroneCollection']], [b'Query internal execution time: 0.089501 milliseconds']]
-
-        redis_db_execute_command_query = MagicMock(return_value = redis_reply)
+        query = ("GRAPH.QUERY", "apigraph", "MATCH (p:collection) RETURN p")
         property_list = redis_reply[0][0]
-        if (b"p.id" in property_list and
-                b"p.operations" in property_list and
-                b"p.type" in property_list):
-            return True
-        else:
-            return False
 
-    def class_endpoints(self):
-        """Test for testing the data stored in classes endpoints
+        assert (
+            b"p.id" in property_list
+            and b"p.operations" in property_list
+            and b"p.type" in property_list
+        ) == True
+
+    def test_classEndpoints(self, redis_reply, redis_db_execute_command_query):
+        """
+        Test for testing the data stored in classes endpoints
         `redis_reply` is data which will get from redis_db_0 on `query` execution.
         """
-        print("testing class endpoints with db=0 ...")
-        query = ('GRAPH.QUERY','apigraph', "MATCH (p:classes) RETURN p")
-        redis_db = redis.StrictRedis(host='localhost', port=6379, db=0)
-
-        redis_reply = [[[b'p.properties', b'p.id', b'p.operations', b'p.type'], [b"['Location']", b'vocab:EntryPoint/Location', b"['POST', 'PUT', 'GET']", b'Location']], [b'Query internal execution time: 0.076224 milliseconds']]
-
-        redis_db_execute_command_query = MagicMock(return_value = redis_reply)
+        query = ("GRAPH.QUERY", "apigraph", "MATCH (p:classes) RETURN p")
         property_list = redis_reply[0][0]
-        if (b"p.id" in property_list and
-                b"p.operations" in property_list and
-                b"p.properties" in property_list and
-                b"p.type" in property_list):
-            return True
-        else:
-            return False
-
-
-class TestRedisStructure(unittest.TestCase):
-    test_redis = Tests()
-
-    @classmethod
-    def setUpClass(cls):
-        cls.test_database=redis.StrictRedis(host='localhost', port=6379, db=5)
-        cls.test_database.set("foo","bar")
-        cls.test_database.set("hydra","redis")
-        print("setUpClass db=5 keys:",cls.test_database.keys())
-
-    def test_entrypoint(self):
-        self.assertTrue(self.test_redis.entry_point())
-
-    def test_collectionEndpoints(self):
-        self.assertTrue(self.test_redis.collection_endpoints())
-
-    def test_classEndpoints(self):
-        self.assertTrue(self.test_redis.class_endpoints())
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.test_database.flushdb()
-        print("tearDownClass db=5 keys:",cls.test_database.get("foo"))
-
-if __name__ == '__main__':
-    unittest.main()
+        assert (
+            b"p.id" in property_list
+            and b"p.operations" in property_list
+            and b"p.properties" in property_list
+            and b"p.type" in property_list
+        ) == True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ graphviz==0.19.1
 httplib2==0.20.2
 hydra-python-core==0.3.1
 PyLD==2.0.3
+pytest==6.2.5
+pytest-mock==3.6.1
 python-socketio==4.4.0
 rdflib==5.0.0
 rdflib-jsonld==0.6.2


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #169 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.6.1 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
I have migrated the test suite to `pytest` from `unittest`. Using `pytest` would improve the readability of the test code with its features like fixtures, mocks, etc.

**To run the test in `/hydrus` folder run `pytest`** 

- Majority of the repetitive code are as `pytest` `fixtures` in `conftest.py` which reduces the clutter in actual test files making it easier to read.
- Fixed `test_agent.py` which was failing tests and builds before.
- Fixed `response` variable in `agent.py` being referenced before assignment.

![Screenshot from 2021-12-30 18-13-45](https://user-images.githubusercontent.com/90337323/147754081-33c7a870-cafd-4012-8810-ea66615ca86f.png)
